### PR TITLE
Modifying scripts to benchmark MySQL for MT TickleDB use-case

### DIFF
--- a/src/db_driver.c
+++ b/src/db_driver.c
@@ -195,6 +195,7 @@ static void db_init(void)
 }
 
 /*
+ * Marker 8:
   Initialize a driver specified by 'name' and return a handle to it
   If NULL is passed as a name, then use the driver passed in --db-driver
   command line option
@@ -206,6 +207,7 @@ db_driver_t *db_create(const char *name)
   db_driver_t    *tmp;
   sb_list_item_t *pos;
 
+//  printf("ThreadId (%d) initiating connection to DB...\n", pthread_self());
   pthread_once(&db_global_once, db_init);
 
   if (!db_global_initialized)
@@ -247,7 +249,7 @@ db_driver_t *db_create(const char *name)
     goto err;
   }
 
-  /* Initialize database driver only once */
+  /* Initialize database driver only once  */
   pthread_mutex_lock(&drv->mutex);
   if (!drv->initialized)
   {
@@ -260,6 +262,9 @@ db_driver_t *db_create(const char *name)
   }
   pthread_mutex_unlock(&drv->mutex);
 
+  /*
+   * mysql_drv_thread_init used here
+   */
   if (drv->ops.thread_init != NULL && drv->ops.thread_init(sb_tls_thread_id))
   {
     log_text(LOG_FATAL, "thread-local driver initialization failed.");
@@ -399,9 +404,9 @@ void db_connection_free(db_conn_t *con)
 }
 
 
-/* Prepare statement */
-
-
+/*
+ * Marker 11: Prepare statement
+ */
 db_stmt_t *db_prepare(db_conn_t *con, const char *query, size_t len)
 {
   db_stmt_t *stmt;
@@ -463,9 +468,9 @@ int db_bind_result(db_stmt_t *stmt, db_bind_t *results, size_t len)
 }
 
 
-/* Execute prepared statement */
-
-
+/*
+ * Marker 15: Execute prepared statement
+ */
 db_result_t *db_execute(db_stmt_t *stmt)
 {
   db_conn_t       *con = stmt->connection;
@@ -484,7 +489,6 @@ db_result_t *db_execute(db_stmt_t *stmt)
   }
 
   rs->statement = stmt;
-
   con->error = con->driver->ops.execute(stmt, rs);
 
   sb_counter_inc(con->thread_id, rs->counter);
@@ -816,6 +820,8 @@ void db_free_row(db_row_t *row)
 
 int db_bulk_insert_init(db_conn_t *con, const char *query, size_t query_len)
 {
+
+//  printf("M1: Bulk Insert init 4 %s ", query);
   drv_caps_t driver_caps;
   int        rc;
 
@@ -866,6 +872,7 @@ int db_bulk_insert_next(db_conn_t *con, const char *query, size_t query_len)
 {
   int rc;
 
+//  printf("M2: Bulk Insert next: %s", query);
   if (con->state == DB_CONN_INVALID)
   {
     log_text(LOG_ALERT, "attempt to use an already closed connection");

--- a/src/lua/internal/sysbench.rand.lua
+++ b/src/lua/internal/sysbench.rand.lua
@@ -32,6 +32,7 @@ uint32_t sb_rand_pareto(uint32_t, uint32_t);
 uint32_t sb_rand_zipfian(uint32_t, uint32_t);
 uint32_t sb_rand_unique(void);
 void sb_rand_str(const char *, char *);
+void sb_rand_alphanumeric_str(const char *, char *);
 void sb_rand_varstr(char *, uint32_t, uint32_t);
 double sb_rand_uniform_double(void);
 ]]
@@ -72,6 +73,13 @@ function sysbench.rand.string(fmt)
    local buflen = #fmt
    local buf = ffi.new("uint8_t[?]", buflen)
    ffi.C.sb_rand_str(fmt, buf)
+   return ffi.string(buf, buflen)
+end
+
+function sysbench.rand.alphanumeric_string(fmt)
+   local buflen = #fmt
+   local buf = ffi.new("uint8_t[?]", buflen)
+   ffi.C.sb_rand_alphanumeric_str(fmt, buf)
    return ffi.string(buf, buflen)
 end
 

--- a/src/lua/internal/sysbench.sql.lua
+++ b/src/lua/internal/sysbench.sql.lua
@@ -18,6 +18,10 @@
 -- SQL API
 -- ----------------------------------------------------------------------
 
+--[[
+   The FFI library allows calling external C functions and using C data structures from pure Lua code.
+   http://luajit.org/ext_ffi.html
+]]--
 ffi = require("ffi")
 
 sysbench.sql = {}
@@ -287,6 +291,7 @@ function connection_methods.bulk_insert_done(self)
                  "db_bulk_insert_done() failed")
 end
 
+-- Marker 10
 function connection_methods.prepare(self, query)
    local stmt = ffi.C.db_prepare(self, query, #query)
    if stmt == nil then
@@ -318,6 +323,8 @@ ffi.metatype("sql_connection", connection_mt)
 
 -- sql_param
 local sql_param = {}
+
+-- Marker 16
 function sql_param.set(self, value)
    local sql_type = sysbench.sql.type
    local btype = self.type
@@ -428,6 +435,7 @@ function statement_methods.bind_param(self, ...)
    return ffi.C.db_bind_param(self, binds, len)
 end
 
+-- Marker 14
 function statement_methods.execute(self)
    local rs = ffi.C.db_execute(self)
    return self.connection:check_error(rs, '<prepared statement>')

--- a/src/lua/oltp_point_select.lua
+++ b/src/lua/oltp_point_select.lua
@@ -24,6 +24,8 @@ require("oltp_common")
 function prepare_statements()
    -- use 1 query per event, rather than sysbench.opt.point_selects which
    -- defaults to 10 in other OLTP scripts
+   print("Am i being called");
+
    sysbench.opt.point_selects=1
 
    prepare_point_selects()

--- a/src/lua/oltp_read_only.lua
+++ b/src/lua/oltp_read_only.lua
@@ -19,9 +19,19 @@
 -- Read-Only OLTP benchmark
 -- ----------------------------------------------------------------------
 
+--[[
+   If you run into these problems-
+   1. ld: library not found for -lssl,
+   https://stackoverflow.com/questions/25979525/cannot-find-lssl-cannot-find-lcrypto-when-installing-mysql-python-using-mar
+   2. ld: library not found for -lgcc, export MACOSX_DEPLOYMENT_TARGET=10.10
+]]--
 require("oltp_common")
 
+local unique_id = tostring( {} ):sub(8)
+
+-- Marker 9
 function prepare_statements()
+--   print("ThreadId "..unique_id.." preparing statements...\n")
    prepare_point_selects()
 
    if not sysbench.opt.skip_trx then
@@ -31,12 +41,13 @@ function prepare_statements()
 
    if sysbench.opt.range_selects then
       prepare_simple_ranges()
-      prepare_sum_ranges()
+      --prepare_sum_ranges()
       prepare_order_ranges()
       prepare_distinct_ranges()
    end
 end
 
+-- Marker 13
 function event()
    if not sysbench.opt.skip_trx then
       begin()

--- a/src/lua/oltp_read_write.lua
+++ b/src/lua/oltp_read_write.lua
@@ -20,8 +20,10 @@
 -- ----------------------------------------------------------------------
 
 require("oltp_common")
+local unique_id = tostring( {} ):sub(8)
 
 function prepare_statements()
+   print(unique_id,"Write prepare invoked now\n");
    if not sysbench.opt.skip_trx then
       prepare_begin()
       prepare_commit()

--- a/src/lua/select_random_points.lua
+++ b/src/lua/select_random_points.lua
@@ -8,6 +8,8 @@
 
 require("oltp_common")
 
+print("THis script is invoked\n");
+
 -- Add random_points to the list of standard OLTP options
 sysbench.cmdline.options.random_points =
    {"Number of random points in the IN() clause in generated SELECTs", 10}
@@ -30,6 +32,7 @@ function cleanup()
 end
 
 function thread_init()
+   print("random point selects in thread init\n");
    drv = sysbench.sql.driver()
    con = drv:connect()
 

--- a/src/lua/select_random_ranges.lua
+++ b/src/lua/select_random_ranges.lua
@@ -8,6 +8,8 @@
 
 require("oltp_common")
 
+print("Random selector is being used\n");
+
 -- Add --number-of-ranges and --delta to the list of standard OLTP options
 sysbench.cmdline.options.number_of_ranges =
    {"Number of random BETWEEN ranges per SELECT", 10}

--- a/src/sb_lua.c
+++ b/src/sb_lua.c
@@ -289,6 +289,7 @@ static int export_options(lua_State *L)
 
 sb_test_t *sb_load_lua(const char *testname)
 {
+    printf("Loading the lua test:%s\n", testname);
   if (testname != NULL)
   {
     char *tmp = strdup(testname);
@@ -370,8 +371,9 @@ void sb_lua_done(void)
 }
 
 
-/* Initialize Lua script */
-
+/*
+ * Marker4: initialize Lua script
+ */
 int sb_lua_op_init(void)
 {
   if (export_options(gstate))
@@ -397,6 +399,9 @@ int sb_lua_op_init(void)
   return 0;
 }
 
+/*
+ * Marker6:
+ */
 int sb_lua_op_thread_init(int thread_id)
 {
   lua_State * L;
@@ -420,6 +425,7 @@ int sb_lua_op_thread_init(int thread_id)
       call_error(L, THREAD_INIT_FUNC);
       return 1;
     }
+    //Reaches here
   }
 
   return 0;
@@ -427,6 +433,7 @@ int sb_lua_op_thread_init(int thread_id)
 
 int sb_lua_op_thread_run(int thread_id)
 {
+//  printf("ThreadId (%d) Lua thread run START...\n", thread_id);
   lua_State * const L = states[thread_id];
 
   lua_getglobal(L, THREAD_RUN_FUNC);
@@ -437,6 +444,7 @@ int sb_lua_op_thread_run(int thread_id)
     call_error(L, THREAD_RUN_FUNC);
     return 1;
   }
+//  printf("ThreadId (%d) Lua thread run END...\n", thread_id);
 
   return 0;
 }
@@ -925,6 +933,7 @@ static bool sb_lua_custom_command_parallel(const char *name)
 
 static int call_custom_command(lua_State *L)
 {
+//  printf("Calling custom command for thread");
   if (export_options(L))
     return 1;
 
@@ -960,6 +969,7 @@ static int call_custom_command(lua_State *L)
 
 static void *cmd_worker_thread(void *arg)
 {
+//  printf("Creating custom thread\n");
   sb_thread_ctxt_t   *ctxt= (sb_thread_ctxt_t *)arg;
 
   sb_tls_thread_id = ctxt->id;
@@ -976,6 +986,7 @@ static void *cmd_worker_thread(void *arg)
   }
 
   call_custom_command(L);
+//  printf("Closing after completion");
 
   sb_lua_close_state(L);
 
@@ -990,6 +1001,7 @@ int sb_lua_call_custom_command(const char *name)
 
   if (sb_lua_custom_command_parallel(name) && sb_globals.threads > 1)
   {
+    printf("Request for N workers. Creating %d workers", sb_globals.threads);
     int err;
 
     if ((err = sb_thread_create_workers(cmd_worker_thread)))

--- a/src/sb_rand.c
+++ b/src/sb_rand.c
@@ -343,6 +343,20 @@ void sb_rand_str(const char *fmt, char *buf)
   }
 }
 
+void sb_rand_alphanumeric_str(const char *fmt, char *buf)
+{
+  unsigned int i;
+
+  for (i=0; fmt[i] != '\0'; i++)
+  {
+//    printf("Randomly generating: %c\n", sb_rand_uniform('0', '2'));
+    if(fmt[i] == '#' || fmt[i] == '@')
+        buf[i] = (sb_rand_uniform('0', '1') == '0'? sb_rand_uniform('0', '9'): sb_rand_uniform('a', 'z'));
+    else
+      buf[i] = fmt[i];
+  }
+}
+
 /*
   Generates a random string of ASCII characters between '0' and 'z' of a length
   between min and max. buf should have enough room for max len bytes. Returns

--- a/src/sb_rand.h
+++ b/src/sb_rand.h
@@ -71,6 +71,7 @@ uint32_t sb_rand_pareto(uint32_t, uint32_t);
 uint32_t sb_rand_zipfian(uint32_t, uint32_t);
 uint32_t sb_rand_unique(void);
 void sb_rand_str(const char *, char *);
+void sb_rand_alphanumeric_str(const char *, char *);
 uint32_t sb_rand_varstr(char *, uint32_t, uint32_t);
 
 #endif /* SB_RAND_H */

--- a/src/sb_thread.c
+++ b/src/sb_thread.c
@@ -38,6 +38,7 @@
 #include "sb_logger.h"
 #include "sysbench.h"
 #include "sb_ck_pr.h"
+#include <unistd.h>
 
 pthread_attr_t  sb_thread_attr;
 
@@ -132,7 +133,11 @@ int sb_thread_create(pthread_t *thread, const pthread_attr_t *attr,
   }
   proxy->start_routine = start_routine;
   proxy->arg = arg;
+  /*
+   * Actual thread creation
+   */
   int rv = pthread_create(thread, attr, thread_start_routine_proxy, proxy);
+  printf("Transaction worker thread created\n");
   if (rv)
   {
     free(proxy);
@@ -155,6 +160,9 @@ int sb_thread_cancel(pthread_t thread)
 #endif
 }
 
+/*
+ * This will create a worker thread and initiate worker_routine in it.
+ */
 int sb_thread_create_workers(void *(*worker_routine)(void*))
 {
   unsigned int i;
@@ -165,7 +173,7 @@ int sb_thread_create_workers(void *(*worker_routine)(void*))
   {
     threads[i].id = i;
   }
-
+  printf("Successfully created %d threads...\n",sb_globals.threads);
 
   for(i = 0; i < sb_globals.threads; i++)
   {

--- a/src/tests/threads/sb_threads.c
+++ b/src/tests/threads/sb_threads.c
@@ -101,7 +101,7 @@ int threads_prepare(void)
     log_text(LOG_FATAL, "Memory allocation failure!");
     return 1;
   }
-  
+  //Marker5: Mutex acquisition
   for(i = 0; i < thread_locks; i++)
     pthread_mutex_init(test_mutexes + i, NULL);
 

--- a/third_party/luajit/luajit/src/host/minilua.c
+++ b/third_party/luajit/luajit/src/host/minilua.c
@@ -5767,6 +5767,7 @@ struct CallS*c=cast(struct CallS*,ud);
 luaD_call(L,c->func,c->nresults);
 }
 static int lua_pcall(lua_State*L,int nargs,int nresults,int errfunc){
+    printf("inside lua call..\n");
 struct CallS c;
 int status;
 ptrdiff_t func;


### PR DESCRIPTION
Modified original lua scripts, and C files to benchmark MySQL for MT TickleDB use case.
[JIRA-](https://mindtickle.atlassian.net/browse/MI-608)

**Completed the Point selects with following config:
Table size: 10M
Schema:**
| sbtestD1 | CREATE TABLE `sbtestD1` (
  `id` varchar(255) NOT NULL,
  `document` json DEFAULT NULL,
  `user_id` varchar(255) GENERATED ALWAYS AS (json_unquote(json_extract(`document`,_utf8mb3'$.user_id'))) VIRTUAL,
  `added_on` bigint(20) GENERATED ALWAYS AS (json_unquote(json_extract(`document`,_utf8mb3'$.added_on'))) VIRTUAL,
  `entity_id` varchar(255) GENERATED ALWAYS AS (json_unquote(json_extract(`document`,_utf8mb3'$.entity_id'))) VIRTUAL,
  `entity_type` varchar(255) GENERATED ALWAYS AS (json_unquote(json_extract(`document`,_utf8mb3'$.entity_type'))) VIRTUAL,
  `completion_status` varchar(255) GENERATED ALWAYS AS (json_unquote(json_extract(`document`,_utf8mb3'$.completion_status'))) VIRTUAL,
  `due_on` bigint(20) GENERATED ALWAYS AS (json_unquote(json_extract(`document`,_utf8mb3'$.due_on'))) VIRTUAL,
  PRIMARY KEY (`id`),
  KEY `user_id` (`user_id`),
  KEY `added_on` (`added_on`),
  KEY `entity_id` (`entity_id`),
  KEY `entity_type` (`entity_type`),
  KEY `completion_status` (`completion_status`),
  KEY `due_on` (`due_on`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci |

**Sysbench query:** 
`for each in 1 2 4 8 16; do sysbench oltp_read_only.lua --threads=$each --time=10 --mysql-user=root --mysql-port=832 --table-size=1000000 --range-selects=off --db-ps-mode=disable --report-interval=1 --point_selects=10 run;sleep 10;done`

TrX size: 10
Threads: 1 2 4 8 16
Run time: 10sec each
Random select range: first 1M

**1.Threads**
queries performed:
read: 31920
write: 0
other: 6384
total: 38304
transactions: 3192 (313.96 per sec.)
queries: 38304 (3767.58 per sec.)
ignored errors: 0 (0.00 per sec.)
reconnects: 0 (0.00 per sec.)

Throughput:
events/s (eps): 313.9648
time elapsed: 10.1667s
total number of events: 3192

Latency (ms):
min: 1.99
avg: 3.13
max: 19.82
95th percentile: 3.68
sum: 9994.58

**2. Threads**
queries performed:
read: 69910
write: 0
other: 13982
total: 83892
transactions: 6991 (682.21 per sec.)
queries: 83892 (8186.48 per sec.)
ignored errors: 0 (0.00 per sec.)
reconnects: 0 (0.00 per sec.)

Throughput:
events/s (eps): 682.2064
time elapsed: 10.2476s
total number of events: 6991

Latency (ms):
min: 1.75
avg: 2.86
max: 15.86
95th percentile: 3.49
sum: 19987.02

4. Threads
queries performed:
read: 146040
write: 0
other: 29208
total: 175248
transactions: 14604 (1411.22 per sec.)
queries: 175248 (16934.61 per sec.)
ignored errors: 0 (0.00 per sec.)
reconnects: 0 (0.00 per sec.)

Throughput:
events/s (eps): 1411.2178
time elapsed: 10.3485s
total number of events: 14604

Latency (ms):
min: 1.55
avg: 2.74
max: 7.83
95th percentile: 3.43
sum: 39967.11

8. Threads
queries performed:
read: 254740
write: 0
other: 50948
total: 305688
transactions: 25474 (2408.16 per sec.)
queries: 305688 (28897.93 per sec.)
ignored errors: 0 (0.00 per sec.)
reconnects: 0 (0.00 per sec.)

Throughput:
events/s (eps): 2408.1609
time elapsed: 10.5782s
total number of events: 25474

Latency (ms):
min: 2.03
avg: 3.14
max: 14.38
95th percentile: 3.89
sum: 79904.89

16. Threads
queries performed:
read: 288790
write: 0
other: 57758
total: 346548
transactions: 28879 (2574.82 per sec.)
queries: 346548 (30897.90 per sec.)
ignored errors: 0 (0.00 per sec.)
reconnects: 0 (0.00 per sec.)

Throughput:
events/s (eps): 2574.8250
time elapsed: 11.2159s
total number of events: 28879

Latency (ms):
min: 2.14
avg: 5.56
max: 166.11
95th percentile: 14.21
sum: 160709.90
